### PR TITLE
fix: re-apply the global cert to apps on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ global-cert:set CRT KEY     # Sets a global ssl endpoint. Can also import from a
 
 ## usage
 
-While Dokku supports per-application SSL certificates, it does not natively provide global certificate setting. This plugin allows setting a global certificate, which will then be imported for all new applications. The interface is similar to that of the official `certs` plugin, though with minor changes to reflect it's usage.
+While Dokku supports per-application SSL certificates, it does not natively provide global certificate setting. This plugin allows setting a global certificate, which will then be imported for all new applications. Updating the global certificate re-applies it to every application that currently uses it, so renewals (for example a rotated wildcard certificate) propagate to existing applications and are served immediately. Applications that have been given their own certificate are left untouched. The interface is similar to that of the official `certs` plugin, though with minor changes to reflect it's usage.
 
 ### certificate setting
 

--- a/internal-functions
+++ b/internal-functions
@@ -54,6 +54,58 @@ fn-is-tar-import() {
   return 0
 }
 
+fn-global-cert-fingerprint() {
+  declare desc="prints the sha256 fingerprint of a certificate, empty when unreadable"
+  local CRT_FILE="$1"
+
+  [[ -r "$CRT_FILE" ]] || return 0
+  openssl x509 -noout -fingerprint -sha256 -in "$CRT_FILE" 2>/dev/null || true
+}
+
+fn-global-cert-certs-set-available() {
+  declare desc="returns 0 if an enabled plugin provides the certs-set trigger"
+  local trigger
+
+  # a plugn trigger exists when some enabled plugin ships an executable script
+  # named after it; certs-set was added to the certs plugin after dokku 0.38.3
+  for trigger in "${PLUGIN_ENABLED_PATH:-/var/lib/dokku/plugins/enabled}"/*/certs-set; do
+    [[ -x "$trigger" ]] && return 0
+  done
+  return 1
+}
+
+fn-global-cert-apply() {
+  declare desc="installs the global cert on an app, preferring the certs-set trigger over certs:add"
+  local APP="$1" CRT_FILE="$2" KEY_FILE="$3"
+
+  if fn-global-cert-certs-set-available; then
+    plugn trigger certs-set "$APP" "$CRT_FILE" "$KEY_FILE"
+  else
+    dokku certs:add "$APP" "$CRT_FILE" "$KEY_FILE"
+  fi
+}
+
+fn-global-cert-propagate() {
+  declare desc="re-applies the global cert to every app currently using the previous global cert"
+  local OLD_FINGERPRINT="$1"
+  local CRT_FILE KEY_FILE app crt
+
+  [[ -n "$OLD_FINGERPRINT" ]] || return 0
+  CRT_FILE="$PLUGIN_CONFIG_ROOT/server.crt"
+  KEY_FILE="$PLUGIN_CONFIG_ROOT/server.key"
+
+  (
+    shopt -s nullglob
+    for crt in "$DOKKU_ROOT"/*/tls/server.crt; do
+      [[ "$(fn-global-cert-fingerprint "$crt")" == "$OLD_FINGERPRINT" ]] || continue
+      app="${crt#"$DOKKU_ROOT"/}"
+      app="${app%%/*}"
+      dokku_log_info1 "Re-applying global certificate to $app"
+      fn-global-cert-apply "$app" "$CRT_FILE" "$KEY_FILE" || true
+    done
+  )
+}
+
 fn-ssl-enabled() {
   local SSL_ENABLED=false
 

--- a/post-app-clone
+++ b/post-app-clone
@@ -12,8 +12,7 @@ hook-post-app-clone-global-cert() {
   local KEY_FILE="$PLUGIN_CONFIG_ROOT/server.key"
 
   if fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT"; then
-    # we should export certs_set as a function in the certs plugin so that this works with the remote cli...
-    dokku certs:add "$APP" "$CRT_FILE" "$KEY_FILE"
+    fn-global-cert-apply "$APP" "$CRT_FILE" "$KEY_FILE"
   fi
 }
 

--- a/post-create
+++ b/post-create
@@ -12,8 +12,7 @@ hook-post-create-global-cert() {
   local KEY_FILE="$PLUGIN_CONFIG_ROOT/server.key"
 
   if fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT"; then
-    # we should export certs_set as a function in the certs plugin so that this works with the remote cli...
-    dokku certs:add "$APP" "$CRT_FILE" "$KEY_FILE"
+    fn-global-cert-apply "$APP" "$CRT_FILE" "$KEY_FILE"
   fi
 }
 

--- a/subcommands/set
+++ b/subcommands/set
@@ -45,11 +45,18 @@ cmd-global-cert-set() {
     dokku_log_fail "Tar archive containing server.crt and server.key expected on stdin"
   fi
 
+  # capture the outgoing global cert's fingerprint before it is overwritten, so
+  # apps that currently use it can be re-issued the new cert below
+  local OLD_FINGERPRINT
+  OLD_FINGERPRINT="$(fn-global-cert-fingerprint "$PLUGIN_CONFIG_ROOT/server.crt")"
+
   mkdir -p "$PLUGIN_CONFIG_ROOT"
   cp "$CRT_FILE" "$PLUGIN_CONFIG_ROOT/server.crt"
   cp "$KEY_FILE" "$PLUGIN_CONFIG_ROOT/server.key"
   chmod 750 "$PLUGIN_CONFIG_ROOT"
   chmod 640 "$PLUGIN_CONFIG_ROOT/server.crt" "$PLUGIN_CONFIG_ROOT/server.key"
+
+  fn-global-cert-propagate "$OLD_FINGERPRINT"
 }
 
 cmd-global-cert-set "$@"

--- a/tests/global_cert_hooks.bats
+++ b/tests/global_cert_hooks.bats
@@ -7,6 +7,7 @@ setup() {
   APP="$(new_app_name)"
   APP2=""
   SRC=""
+  OWN=""
 }
 
 teardown() {
@@ -14,12 +15,17 @@ teardown() {
   [ -n "${APP2:-}" ] && cleanup_app "$APP2"
   reset_global_cert
   [ -n "${SRC:-}" ] && rm -rf "$SRC"
+  [ -n "${OWN:-}" ] && rm -rf "$OWN"
   return 0
 }
 
+# Install a global cert whose CN/SAN is <cn> (default global.example.com). Safe
+# to call more than once per test; the prior fixture dir is removed first.
 install_fixture_cert() {
+  local cn="${1:-global.example.com}"
+  [ -n "${SRC:-}" ] && rm -rf "$SRC"
   SRC="$(gc_fixture_dir)"
-  make_self_signed_cert "$SRC" "global.example.com" "DNS:global.example.com"
+  make_self_signed_cert "$SRC" "$cn" "DNS:${cn}"
   dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
 }
 
@@ -47,6 +53,39 @@ install_fixture_cert() {
   APP2="$(new_app_name)"
   dokku apps:clone --skip-deploy "$APP" "$APP2"
   $SUDO test -f "$(app_tls_crt "$APP2")"
+}
+
+@test "(global-cert:set) re-applies an updated global cert to apps that use it" {
+  install_fixture_cert
+  create_app "$APP"
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+
+  # updating the global cert propagates to the app that is using it
+  install_fixture_cert "updated.example.com"
+
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"updated.example.com"* ]]
+}
+
+@test "(global-cert:set) leaves an app with its own certificate untouched" {
+  install_fixture_cert
+  create_app "$APP"
+
+  # give the app its own, independent certificate
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  # updating the global cert must not overwrite the app's own certificate
+  install_fixture_cert "updated.example.com"
+
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"own.example.com"* ]]
+  [[ "$output" != *"updated.example.com"* ]]
 }
 
 @test "(post-create) fails when fired without an app" {

--- a/tests/global_cert_remove.bats
+++ b/tests/global_cert_remove.bats
@@ -4,10 +4,12 @@ load 'test_helper'
 
 setup() {
   reset_global_cert
+  APP="$(new_app_name)"
   SRC=""
 }
 
 teardown() {
+  cleanup_app "$APP"
   reset_global_cert
   [ -n "${SRC:-}" ] && rm -rf "$SRC"
   return 0
@@ -15,7 +17,7 @@ teardown() {
 
 install_fixture_cert() {
   SRC="$(gc_fixture_dir)"
-  make_self_signed_cert "$SRC" "global.example.com"
+  make_self_signed_cert "$SRC" "global.example.com" "DNS:global.example.com"
   dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
 }
 
@@ -32,6 +34,25 @@ install_fixture_cert() {
   $SUDO test ! -f "$(global_cert_key)"
   run global_cert_enabled
   [ "$output" = "false" ]
+}
+
+@test "(global-cert:remove) leaves apps that use the global cert with a working copy" {
+  install_fixture_cert
+  create_app "$APP"
+  $SUDO test -f "$(app_tls_crt "$APP")"
+
+  run dokku global-cert:remove
+  [ "$status" -eq 0 ]
+
+  # the app keeps its own copy of the certificate
+  $SUDO test -f "$(app_tls_crt "$APP")"
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+
+  # the global cert itself is gone
+  $SUDO test ! -f "$(global_cert_crt)"
+  $SUDO test ! -f "$(global_cert_key)"
 }
 
 @test "(global-cert:remove) fails when no global cert is defined" {


### PR DESCRIPTION
Previously the global certificate was copied into each application only when the application was created, so updating it left existing applications serving the stale certificate until they were recreated. `global-cert:set` now re-applies the certificate to every application that is currently using it, so renewals propagate immediately while applications that have their own certificate are left untouched.

Fixes #3.
