### PR TITLE
ci: also test a dokku version with the certs-set trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         dokku_version:
+          # 0.38.3 predates the certs-set trigger (exercises the certs:add
+          # fallback); 0.38.22 ships it (exercises the trigger path)
           - 0.38.3
+          - 0.38.22
 
     env:
       DOKKU_VERSION: ${{ matrix.dokku_version }}
@@ -66,7 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         dokku_version:
+          # 0.38.3 predates the certs-set trigger (exercises the certs:add
+          # fallback); 0.38.22 ships it (exercises the trigger path)
           - 0.38.3
+          - 0.38.22
 
     env:
       DOKKU_VERSION: ${{ matrix.dokku_version }}


### PR DESCRIPTION
The `certs-set` plugin trigger was added to dokku after 0.38.3, so the plugin prefers it when available and falls back to `dokku certs:add` otherwise. The CI matrix only ran 0.38.3, which exercises the fallback path but never the trigger path. Adding 0.38.22, which ships the trigger, keeps both paths covered so a regression in either is caught. This follows up on #12.
