### PR TITLE
fix: apply the global cert to existing apps on set

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ dokku plugin:install https://github.com/josegonzalez/dokku-global-cert.git globa
 global-cert:generate        # Generate a key and certificate signing request (and self-signed certificate)
 global-cert:remove          # Remove the SSL configuration
 global-cert:report [<flag>] # Displays a global ssl report
-global-cert:set CRT KEY     # Sets a global ssl endpoint. Can also import from a tarball on stdin
+global-cert:set [--force] CRT KEY # Sets a global ssl endpoint. Can also import from a tarball on stdin
 ```
 
 ## usage
 
-While Dokku supports per-application SSL certificates, it does not natively provide global certificate setting. This plugin allows setting a global certificate, which will then be imported for all new applications. Updating the global certificate re-applies it to every application that currently uses it, so renewals (for example a rotated wildcard certificate) propagate to existing applications and are served immediately. Applications that have been given their own certificate are left untouched. The interface is similar to that of the official `certs` plugin, though with minor changes to reflect it's usage.
+While Dokku supports per-application SSL certificates, it does not natively provide global certificate setting. This plugin allows setting a global certificate, which is imported for all new applications and applied to every existing application that does not already have its own certificate. Updating the global certificate also re-applies it to every application that currently uses it, so renewals (for example a rotated wildcard certificate) propagate to existing applications and are served immediately. Applications that have been given their own certificate are left untouched unless `--force` is passed. The interface is similar to that of the official `certs` plugin, though with minor changes to reflect it's usage.
 
 ### certificate setting
 
@@ -44,6 +44,20 @@ You can also import certs without using `stdin`, and instead specifying a full p
 
 ```shell
 dokku global-cert:set server.crt server.key
+```
+
+Setting the global certificate applies it to every existing application that does not already have its own certificate, so applications created before the global certificate was set start serving it immediately. Re-running `global-cert:set` is therefore also the way to apply the certificate to applications on an existing install.
+
+To re-apply the global certificate to every application - including applications that were given their own certificate - pass `--force`:
+
+```shell
+dokku global-cert:set --force server.crt server.key
+```
+
+The `--force` flag also works as a global flag:
+
+```shell
+dokku --force global-cert:set server.crt server.key
 ```
 
 ### certificate removal

--- a/internal-functions
+++ b/internal-functions
@@ -85,25 +85,36 @@ fn-global-cert-apply() {
   fi
 }
 
-fn-global-cert-propagate() {
-  declare desc="re-applies the global cert to every app currently using the previous global cert"
-  local OLD_FINGERPRINT="$1"
-  local CRT_FILE KEY_FILE app crt
+fn-global-cert-sync() {
+  declare desc="applies the global cert to apps lacking their own cert; --force reapplies to every app"
+  local OLD_FINGERPRINT="$1" FORCE="${2:-false}"
+  local CRT_FILE KEY_FILE apps app crt fingerprint
 
-  [[ -n "$OLD_FINGERPRINT" ]] || return 0
+  fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT" || return 0
   CRT_FILE="$PLUGIN_CONFIG_ROOT/server.crt"
   KEY_FILE="$PLUGIN_CONFIG_ROOT/server.key"
 
-  (
-    shopt -s nullglob
-    for crt in "$DOKKU_ROOT"/*/tls/server.crt; do
-      [[ "$(fn-global-cert-fingerprint "$crt")" == "$OLD_FINGERPRINT" ]] || continue
-      app="${crt#"$DOKKU_ROOT"/}"
-      app="${app%%/*}"
+  # dokku_apps hard-fails ("You haven't deployed any applications yet") when there
+  # are no apps; swallow that so a first-time set with no apps is a no-op.
+  apps="$(dokku_apps 2>/dev/null)" || apps=""
+  [[ -n "$apps" ]] || return 0
+
+  while IFS= read -r app; do
+    [[ -n "$app" ]] || continue
+    crt="$DOKKU_ROOT/$app/tls/server.crt"
+    if [[ "$FORCE" != "true" ]] && [[ -e "$crt" ]]; then
+      # the app has a cert: only replace it when it is the previous global cert
+      # (a renewal); an app-specific cert is left untouched
+      fingerprint="$(fn-global-cert-fingerprint "$crt")"
+      [[ -n "$OLD_FINGERPRINT" && "$fingerprint" == "$OLD_FINGERPRINT" ]] || continue
+    fi
+    if [[ -e "$crt" ]]; then
       dokku_log_info1 "Re-applying global certificate to $app"
-      fn-global-cert-apply "$app" "$CRT_FILE" "$KEY_FILE" || true
-    done
-  )
+    else
+      dokku_log_info1 "Applying global certificate to $app"
+    fi
+    fn-global-cert-apply "$app" "$CRT_FILE" "$KEY_FILE" || true
+  done <<< "$apps"
 }
 
 fn-ssl-enabled() {
@@ -164,7 +175,7 @@ fn-global-cert-help-content() {
   declare desc="return $PLUGIN_COMMAND_PREFIX plugin help content"
   cat<<help_content
     ${PLUGIN_COMMAND_PREFIX}, Alias for certs:help
-    ${PLUGIN_COMMAND_PREFIX}:set CRT KEY, Adds a global ssl endpoint. Can also import from a tarball on stdin
+    ${PLUGIN_COMMAND_PREFIX}:set [--force] CRT KEY, Adds a global ssl endpoint. Can also import from a tarball on stdin
     ${PLUGIN_COMMAND_PREFIX}:generate, Generate a key and certificate signing request (and self-signed certificate)
     ${PLUGIN_COMMAND_PREFIX}:remove, Remove the SSL configuration
     ${PLUGIN_COMMAND_PREFIX}:report [<flag>], Displays a global ssl report

--- a/subcommands/set
+++ b/subcommands/set
@@ -7,10 +7,28 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 cmd-global-cert-set() {
   #E set a global certificate combination using a full path on disk
   #E dokku $PLUGIN_COMMAND_PREFIX:set server.crt server.key
+  #E reapply the certificate to every app including apps with their own cert
+  #E dokku $PLUGIN_COMMAND_PREFIX:set --force server.crt server.key
   #A crt-file, path to the certificate file
   #A key-file, path to the key file
+  #F --force, reapplies the certificate to every app including apps with their own cert
   declare desc="imports an SSL cert/key combo either on STDIN via a tarball or from specified cert/key filenames"
   local cmd="$PLUGIN_COMMAND_PREFIX:set" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+
+  local FORCE=false
+  # dokku's global `--force` (e.g. `dokku --force global-cert:set ...`) is consumed by the
+  # cli before it reaches this subcommand, but parse_args exports it as this env var.
+  [[ "${DOKKU_APPS_FORCE_DELETE:-}" == "1" ]] && FORCE=true
+
+  local positional=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f | --force) FORCE=true; shift ;;
+      *) positional+=("$1"); shift ;;
+    esac
+  done
+  set -- "${positional[@]}"
+
   declare CRT_FILE="$1" KEY_FILE="$2"
 
   if fn-is-file-import "$CRT_FILE" "$KEY_FILE"; then
@@ -56,7 +74,7 @@ cmd-global-cert-set() {
   chmod 750 "$PLUGIN_CONFIG_ROOT"
   chmod 640 "$PLUGIN_CONFIG_ROOT/server.crt" "$PLUGIN_CONFIG_ROOT/server.key"
 
-  fn-global-cert-propagate "$OLD_FINGERPRINT"
+  fn-global-cert-sync "$OLD_FINGERPRINT" "$FORCE"
 }
 
 cmd-global-cert-set "$@"

--- a/tests/global_cert_hooks.bats
+++ b/tests/global_cert_hooks.bats
@@ -20,13 +20,14 @@ teardown() {
 }
 
 # Install a global cert whose CN/SAN is <cn> (default global.example.com). Safe
-# to call more than once per test; the prior fixture dir is removed first.
+# to call more than once per test; the prior fixture dir is removed first. Any
+# arguments after <cn> are forwarded to `global-cert:set` (e.g. --force).
 install_fixture_cert() {
-  local cn="${1:-global.example.com}"
+  local cn="${1:-global.example.com}"; shift || true
   [ -n "${SRC:-}" ] && rm -rf "$SRC"
   SRC="$(gc_fixture_dir)"
   make_self_signed_cert "$SRC" "$cn" "DNS:${cn}"
-  dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+  dokku global-cert:set "$@" "${SRC}/server.crt" "${SRC}/server.key"
 }
 
 @test "(post-create) applies the global cert to a newly created app" {
@@ -86,6 +87,77 @@ install_fixture_cert() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"own.example.com"* ]]
   [[ "$output" != *"updated.example.com"* ]]
+}
+
+@test "(global-cert:set) applies the global cert to a pre-existing app without a certificate" {
+  # the app exists before any global cert is set, so it starts without a cert
+  create_app "$APP"
+  $SUDO test ! -f "$(app_tls_crt "$APP")"
+
+  # setting the global cert now applies it to the pre-existing app
+  install_fixture_cert
+  $SUDO test -f "$(app_tls_crt "$APP")"
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+}
+
+@test "(global-cert:set) leaves a pre-existing app with its own certificate untouched" {
+  create_app "$APP"
+
+  # give the app its own certificate before any global cert exists
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  # setting the global cert for the first time must not clobber the app's own cert
+  install_fixture_cert
+
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"own.example.com"* ]]
+  [[ "$output" != *"global.example.com"* ]]
+}
+
+@test "(global-cert:set --force) replaces an app-specific certificate on every app" {
+  install_fixture_cert
+  create_app "$APP"
+
+  # give the app its own certificate
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  # --force reapplies the global cert to every app, replacing the app-specific one
+  install_fixture_cert "updated.example.com" --force
+
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"updated.example.com"* ]]
+  [[ "$output" != *"own.example.com"* ]]
+}
+
+@test "(dokku --force global-cert:set) replaces an app-specific certificate on every app" {
+  install_fixture_cert
+  create_app "$APP"
+
+  # give the app its own certificate
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  # the global --force flag is stripped by the cli before the subcommand sees it,
+  # so this exercises the DOKKU_APPS_FORCE_DELETE path
+  rm -rf "$SRC"
+  SRC="$(gc_fixture_dir)"
+  make_self_signed_cert "$SRC" "forced.example.com" "DNS:forced.example.com"
+  run dokku --force global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+  [ "$status" -eq 0 ]
+
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"forced.example.com"* ]]
+  [[ "$output" != *"own.example.com"* ]]
 }
 
 @test "(post-create) fails when fired without an app" {


### PR DESCRIPTION
Previously the global certificate was only attached to applications through the create hooks, so applications that already existed when the certificate was set were never given it and continued to serve plain HTTP. `global-cert:set` now applies the certificate to every existing application that does not have its own certificate, and a `--force` flag re-applies it to every application including those that were given an app-specific certificate.

Closes #2
