### PR TITLE
feat: add global-cert:apply for existing apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ dokku plugin:install https://github.com/josegonzalez/dokku-global-cert.git globa
 ## commands
 
 ```shell
+global-cert:apply <app>...  # Applies the global certificate to one or more existing apps, overwriting any certificate they already have
 global-cert:generate        # Generate a key and certificate signing request (and self-signed certificate)
 global-cert:remove          # Remove the SSL configuration
 global-cert:report [<flag>] # Displays a global ssl report
@@ -59,6 +60,22 @@ The `--force` flag also works as a global flag:
 ```shell
 dokku --force global-cert:set server.crt server.key
 ```
+
+### applying the global certificate to an existing app
+
+The `global-cert:apply` command applies the currently stored global certificate to one or more existing applications, overwriting whatever certificate each application already has. It reuses the certificate already set with `global-cert:set`, so no certificate files are needed:
+
+```shell
+dokku global-cert:apply node-js-app
+```
+
+Multiple applications can be given in a single invocation:
+
+```shell
+dokku global-cert:apply node-js-app python-app
+```
+
+Unlike `global-cert:set`, which leaves applications with their own certificate untouched, `global-cert:apply` always overwrites the certificate on the named applications. This is the way to switch an application that was given its own certificate - for example one issued by `dokku-letsencrypt` - back to the global certificate. A global certificate must be set first; applying to an application that does not exist, or when no global certificate is set, fails.
 
 ### certificate removal
 

--- a/internal-functions
+++ b/internal-functions
@@ -175,6 +175,7 @@ fn-global-cert-help-content() {
   declare desc="return $PLUGIN_COMMAND_PREFIX plugin help content"
   cat<<help_content
     ${PLUGIN_COMMAND_PREFIX}, Alias for certs:help
+    ${PLUGIN_COMMAND_PREFIX}:apply <app>..., Applies the global certificate to one or more existing apps, overwriting any certificate they already have
     ${PLUGIN_COMMAND_PREFIX}:set [--force] CRT KEY, Adds a global ssl endpoint. Can also import from a tarball on stdin
     ${PLUGIN_COMMAND_PREFIX}:generate, Generate a key and certificate signing request (and self-signed certificate)
     ${PLUGIN_COMMAND_PREFIX}:remove, Remove the SSL configuration

--- a/subcommands/apply
+++ b/subcommands/apply
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+source "$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")" )" && pwd)/config"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/global-cert/internal-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+cmd-global-cert-apply() {
+  #E apply the stored global certificate to a single existing app
+  #E dokku $PLUGIN_COMMAND_PREFIX:apply node-js-app
+  #E apply the stored global certificate to multiple apps at once
+  #E dokku $PLUGIN_COMMAND_PREFIX:apply node-js-app python-app
+  #A app..., one or more apps to apply the global certificate to
+  declare desc="applies the stored global certificate to one or more existing apps, overwriting any certificate they already have"
+  local cmd="$PLUGIN_COMMAND_PREFIX:apply" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  # count positional args with $# rather than an array length; the help
+  # renderer greps for hash-A style annotations and would misread the latter
+  [[ "$#" -eq 0 ]] && dokku_log_fail "Please specify an app to run the command on"
+  declare APP_LIST=("$@")
+
+  if ! fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT"; then
+    dokku_log_fail "A global SSL endpoint is not defined"
+  fi
+
+  local app
+  for app in "${APP_LIST[@]}"; do
+    verify_app_name "$app"
+  done
+
+  local CRT_FILE="$PLUGIN_CONFIG_ROOT/server.crt"
+  local KEY_FILE="$PLUGIN_CONFIG_ROOT/server.key"
+  for app in "${APP_LIST[@]}"; do
+    dokku_log_info1 "Applying global certificate to $app"
+    fn-global-cert-apply "$app" "$CRT_FILE" "$KEY_FILE"
+  done
+}
+
+cmd-global-cert-apply "$@"

--- a/tests/global_cert_apply.bats
+++ b/tests/global_cert_apply.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  reset_global_cert
+  APP="$(new_app_name)"
+  APP2=""
+  SRC=""
+  OWN=""
+}
+
+teardown() {
+  cleanup_app "$APP"
+  [ -n "${APP2:-}" ] && cleanup_app "$APP2"
+  reset_global_cert
+  [ -n "${SRC:-}" ] && rm -rf "$SRC"
+  [ -n "${OWN:-}" ] && rm -rf "$OWN"
+  return 0
+}
+
+# Install a global cert whose CN/SAN is <cn> (default global.example.com). The
+# prior fixture dir is removed first so it is safe to call more than once.
+install_fixture_cert() {
+  local cn="${1:-global.example.com}"
+  [ -n "${SRC:-}" ] && rm -rf "$SRC"
+  SRC="$(gc_fixture_dir)"
+  make_self_signed_cert "$SRC" "$cn" "DNS:${cn}"
+  dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+}
+
+@test "(global-cert:apply) applies the global cert to an app without a certificate" {
+  install_fixture_cert
+  # create the app before the global cert exists so it starts without a cert
+  create_app "$APP"
+
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+  $SUDO test -f "$(app_tls_crt "$APP")"
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+}
+
+@test "(global-cert:apply) overwrites an app's own certificate with the global cert" {
+  install_fixture_cert
+  create_app "$APP"
+
+  # give the app its own, independent certificate
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+  [[ "$output" != *"own.example.com"* ]]
+}
+
+@test "(global-cert:apply) applies the global cert to multiple apps at once" {
+  install_fixture_cert
+  create_app "$APP"
+  APP2="$(new_app_name)"
+  create_app "$APP2"
+
+  run dokku global-cert:apply "$APP" "$APP2"
+  [ "$status" -eq 0 ]
+
+  $SUDO test -f "$(app_tls_crt "$APP")"
+  $SUDO test -f "$(app_tls_crt "$APP2")"
+  run dokku certs:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+  run dokku certs:report "$APP2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"global.example.com"* ]]
+}
+
+@test "(global-cert:apply) fails when no global cert is set" {
+  create_app "$APP"
+
+  run dokku global-cert:apply "$APP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"A global SSL endpoint is not defined"* ]]
+}
+
+@test "(global-cert:apply) fails when the app does not exist" {
+  install_fixture_cert
+
+  run dokku global-cert:apply "does-not-exist-$$"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "(global-cert:apply) fails when no app is specified" {
+  install_fixture_cert
+
+  run dokku global-cert:apply
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Please specify an app to run the command on"* ]]
+}

--- a/tests/global_cert_help.bats
+++ b/tests/global_cert_help.bats
@@ -6,7 +6,7 @@ load 'test_helper'
   run dokku global-cert
   [ "$status" -eq 0 ]
   [[ "$output" == *"global-cert"* ]]
-  for subcommand in generate remove report set; do
+  for subcommand in apply generate remove report set; do
     [[ "$output" == *"global-cert:${subcommand}"* ]]
   done
 }
@@ -14,7 +14,7 @@ load 'test_helper'
 @test "(global-cert:help) lists every subcommand" {
   run dokku global-cert:help
   [ "$status" -eq 0 ]
-  for subcommand in generate remove report set; do
+  for subcommand in apply generate remove report set; do
     [[ "$output" == *"global-cert:${subcommand}"* ]]
   done
 }
@@ -22,9 +22,18 @@ load 'test_helper'
 @test "(global-cert:default) aliases the help output" {
   run dokku global-cert:default
   [ "$status" -eq 0 ]
-  for subcommand in generate remove report set; do
+  for subcommand in apply generate remove report set; do
     [[ "$output" == *"global-cert:${subcommand}"* ]]
   done
+}
+
+@test "(global-cert:help apply) prints per-subcommand usage" {
+  run dokku global-cert:help apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"usage:"* ]]
+  [[ "$output" == *"global-cert:apply"* ]]
+  # the #A argument annotation renders as an arguments section
+  [[ "$output" == *"app"* ]]
 }
 
 @test "(global-cert:help set) prints per-subcommand usage" {


### PR DESCRIPTION
Adds a `global-cert:apply <app>...` command that applies the stored global certificate to one or more existing apps, overwriting whatever certificate each app currently has. This makes it possible to move an app that was given its own certificate, such as one issued by `dokku-letsencrypt`, back onto the global certificate without manual file edits.

Closes #7
