### PR TITLE
feat: standardize global-cert:report and add json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dokku plugin:install https://github.com/josegonzalez/dokku-global-cert.git globa
 global-cert:apply <app>...  # Applies the global certificate to one or more existing apps, overwriting any certificate they already have
 global-cert:generate        # Generate a key and certificate signing request (and self-signed certificate)
 global-cert:remove          # Remove the SSL configuration
-global-cert:report [<flag>] # Displays a global ssl report
+global-cert:report [<app>|--global] [<flag>] # Displays a global-cert report for one or more apps
 global-cert:set [--force] CRT KEY # Sets a global ssl endpoint. Can also import from a tarball on stdin
 ```
 
@@ -86,3 +86,33 @@ dokku global-cert:remove
 ```
 
 If the global certificate is removed, existing applications will continue to have the global certificate set.
+
+### reporting
+
+The `global-cert:report` command displays the global certificate status. With no arguments it prints one block per application, each showing whether that application currently serves the global certificate (`--global-cert-applied`) alongside the global certificate's properties:
+
+```shell
+dokku global-cert:report
+dokku global-cert:report node-js-app
+```
+
+An application serves the global certificate when its certificate matches the one stored by `global-cert:set`; an application given its own certificate reports `--global-cert-applied` as `false`.
+
+Pass `--global` to report on the global certificate itself instead of an application:
+
+```shell
+dokku global-cert:report --global
+```
+
+A single value can be fetched by passing the corresponding flag, which is useful for scripting:
+
+```shell
+dokku global-cert:report node-js-app --global-cert-applied
+dokku global-cert:report --global --global-cert-enabled
+```
+
+The report can also be emitted as JSON with `--format json`, in which case the keys are the flag names with the leading `--global-cert-` stripped. The `--format` flag cannot be combined with a single info flag:
+
+```shell
+dokku global-cert:report --global --format json
+```

--- a/internal-functions
+++ b/internal-functions
@@ -117,6 +117,35 @@ fn-global-cert-sync() {
   done <<< "$apps"
 }
 
+fn-global-cert-applied() {
+  declare desc="returns true if the app currently serves the global certificate"
+  local APP="$1"
+  local APP_CRT GLOBAL_CRT APP_FINGERPRINT GLOBAL_FINGERPRINT
+
+  # no global cert means nothing can be applied
+  if ! fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT"; then
+    echo "false"
+    return
+  fi
+
+  APP_CRT="$DOKKU_ROOT/$APP/tls/server.crt"
+  if [[ ! -e "$APP_CRT" ]]; then
+    echo "false"
+    return
+  fi
+
+  # the app serves the global cert when its leaf cert matches the global one;
+  # this is the same fingerprint comparison fn-global-cert-sync relies on
+  GLOBAL_CRT="$PLUGIN_CONFIG_ROOT/server.crt"
+  APP_FINGERPRINT="$(fn-global-cert-fingerprint "$APP_CRT")"
+  GLOBAL_FINGERPRINT="$(fn-global-cert-fingerprint "$GLOBAL_CRT")"
+  if [[ -n "$APP_FINGERPRINT" ]] && [[ "$APP_FINGERPRINT" == "$GLOBAL_FINGERPRINT" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 fn-ssl-enabled() {
   local SSL_ENABLED=false
 
@@ -183,13 +212,101 @@ fn-global-cert-help-content() {
 help_content
 }
 
-cmd-global-cert-report() {
-  declare desc="Display the configured consul registration status for an application"
-  declare cmd="$PLUGIN_COMMAND_PREFIX:report" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
-  declare INFO_FLAG="$1"
-  local flag flag_map key match valid_flags value_exists
+fn-global-cert-report-parse-args() {
+  declare desc="strip --format and --global from a report invocation"
+  REPORT_FORMAT="stdout"
+  REPORT_IS_GLOBAL="false"
+  REPORT_ARGS=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        REPORT_FORMAT="$2"
+        shift 2
+        ;;
+      --global)
+        REPORT_IS_GLOBAL="true"
+        shift
+        ;;
+      *)
+        REPORT_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
 
-  flag_map=(
+fn-global-cert-report-validate-format() {
+  declare desc="reject --format when combined with an info flag"
+  declare FORMAT="$1" INFO_FLAG="$2"
+  if [[ "$FORMAT" != "stdout" ]] && [[ -n "$INFO_FLAG" ]]; then
+    dokku_log_fail "--format flag cannot be specified when specifying an info flag"
+  fi
+}
+
+fn-global-cert-report-emit-json() {
+  declare desc="emit a flag_map as a JSON object, stripping the --global-cert- key prefix"
+  declare flag_map_name="$1"
+  local -n flag_map_ref="$flag_map_name"
+  local json_output="{}"
+  local flag key value
+  for flag in "${flag_map_ref[@]}"; do
+    key="$(echo "$flag" | cut -d':' -f1 | sed 's/^--global-cert-//')"
+    value="$(echo "$flag" | cut -d':' -f2- | sed 's/^ //')"
+    json_output="$(echo "$json_output" | jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}')"
+  done
+  echo "$json_output"
+}
+
+cmd-global-cert-report() {
+  declare desc="displays a global-cert report for one or more apps"
+  declare cmd="$PLUGIN_COMMAND_PREFIX:report" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  fn-global-cert-report-parse-args "$@"
+  set -- "${REPORT_ARGS[@]}"
+
+  declare APP="${1:-}" INFO_FLAG="${2:-}"
+  local INSTALLED_APPS app
+  # dokku_apps hard-fails ("You haven't deployed any applications yet") when there
+  # are no apps; the exit escapes the command substitution, so catch it at the
+  # assignment level (an inner `|| true` would be skipped by the exit)
+  INSTALLED_APPS="$(dokku_apps 2>/dev/null)" || INSTALLED_APPS=""
+
+  # a leading flag means no app was given, only an info flag
+  if [[ -n "$APP" ]] && [[ "$APP" == --* ]]; then
+    INFO_FLAG="$APP"
+    APP=""
+  fi
+
+  if [[ "$REPORT_IS_GLOBAL" == "true" ]]; then
+    APP="--global"
+  fi
+
+  if [[ "$APP" == "--global" ]]; then
+    cmd-global-cert-report-single "--global" "$INFO_FLAG" "$REPORT_FORMAT"
+  elif [[ -z "$APP" ]]; then
+    for app in $INSTALLED_APPS; do
+      cmd-global-cert-report-single "$app" "$INFO_FLAG" "$REPORT_FORMAT" | tee || true
+    done
+  else
+    cmd-global-cert-report-single "$APP" "$INFO_FLAG" "$REPORT_FORMAT"
+  fi
+}
+
+cmd-global-cert-report-single() {
+  declare desc="display the global-cert status for a single app or the global cert"
+  declare APP="$1" INFO_FLAG="$2" FORMAT="${3:-stdout}"
+  local flag flag_map key match valid_flags value_exists value size
+
+  if [[ "$APP" != "--global" ]]; then
+    verify_app_name "$APP"
+  fi
+
+  flag_map=()
+  # applied is the only app-specific fact; the global cert properties are
+  # identical for every app and are dropped from the --global scope
+  if [[ "$APP" != "--global" ]]; then
+    flag_map+=("--global-cert-applied: $(fn-global-cert-applied "$APP")")
+  fi
+  flag_map+=(
     "--global-cert-dir: $PLUGIN_CONFIG_ROOT"
     "--global-cert-enabled: $(fn-ssl-enabled)"
     "--global-cert-expires-at: $(fn-ssl-expires-at)"
@@ -199,11 +316,23 @@ cmd-global-cert-report() {
     "--global-cert-subject: $(fn-ssl-subject)"
     "--global-cert-verified: $(fn-ssl-verified)"
   )
+
+  fn-global-cert-report-validate-format "$FORMAT" "$INFO_FLAG"
+
+  if [[ "$FORMAT" == "json" ]]; then
+    fn-global-cert-report-emit-json flag_map
+    return
+  fi
+
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2_quiet "Global SSL Information"
+    if [[ "$APP" == "--global" ]]; then
+      dokku_log_info2_quiet "global global-cert information"
+    else
+      dokku_log_info2_quiet "${APP} global-cert information"
+    fi
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
-      dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"
+      dokku_log_verbose "$(printf "%-30s %-25s" "${key^}" "${flag#*: }")"
     done
   else
     match=false

--- a/subcommands/report
+++ b/subcommands/report
@@ -3,8 +3,16 @@ source "$PLUGIN_AVAILABLE_PATH/global-cert/internal-functions"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 global-cert-report-cmd() {
-  #E get a report on the global certificate configuration
+  #E get a report on every app's global certificate status
   #E dokku $PLUGIN_COMMAND_PREFIX:report
+  #E get the report for a single app
+  #E dokku $PLUGIN_COMMAND_PREFIX:report node-js-app
+  #E get a report on the global certificate itself
+  #E dokku $PLUGIN_COMMAND_PREFIX:report --global
+  #A app, an app to report on (or --global for the global certificate)
+  #F --format, output format, either stdout (default) or json
+  #F --global, report on the global certificate instead of an app
+  #F --global-cert-applied, whether the app currently serves the global certificate
   #F --global-cert-dir,
   #F --global-cert-enabled,
   #F --global-cert-expires-at,
@@ -13,9 +21,9 @@ global-cert-report-cmd() {
   #F --global-cert-starts-at,
   #F --global-cert-subject,
   #F --global-cert-verified,
-  declare desc="display the configured global-cert status for an application"
+  declare desc="displays a global-cert report for one or more apps"
   local cmd="$PLUGIN_COMMAND_PREFIX:report" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
-  declare INFO_FLAG="$1"
+  declare APP="$1" INFO_FLAG="$2"
 
   cmd-global-cert-report "$@"
 }

--- a/tests/global_cert_report.bats
+++ b/tests/global_cert_report.bats
@@ -4,12 +4,16 @@ load 'test_helper'
 
 setup() {
   reset_global_cert
+  APP="$(new_app_name)"
   SRC=""
+  OWN=""
 }
 
 teardown() {
+  cleanup_app "$APP"
   reset_global_cert
   [ -n "${SRC:-}" ] && rm -rf "$SRC"
+  [ -n "${OWN:-}" ] && rm -rf "$OWN"
   return 0
 }
 
@@ -21,18 +25,20 @@ install_fixture_cert() {
   dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
 }
 
-# --- no cert installed ------------------------------------------------------
+# --- global scope, no cert installed ----------------------------------------
 
-@test "(global-cert:report) renders a full report" {
-  run dokku global-cert:report
+@test "(global-cert:report) --global renders a full report" {
+  run dokku global-cert:report --global
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Global SSL Information"* ]]
+  [[ "$output" == *"global global-cert information"* ]]
   [[ "$output" == *"Global cert dir"* ]]
   [[ "$output" == *"Global cert enabled"* ]]
   [[ "$output" == *"Global cert hostnames"* ]]
   [[ "$output" == *"Global cert issuer"* ]]
   [[ "$output" == *"Global cert subject"* ]]
   [[ "$output" == *"Global cert verified"* ]]
+  # applied is app-specific and must not appear in the global scope
+  [[ "$output" != *"Global cert applied"* ]]
 }
 
 @test "(global-cert:report) --global-cert-enabled is false without a cert" {
@@ -58,12 +64,18 @@ install_fixture_cert() {
 }
 
 @test "(global-cert:report) rejects an invalid flag" {
-  run dokku global-cert:report --not-a-flag
+  run dokku global-cert:report --global --not-a-flag
   [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid flag passed, valid flags:"* ]]
 }
 
-# --- cert installed ---------------------------------------------------------
+@test "(global-cert:report) --format cannot be combined with an info flag" {
+  run dokku global-cert:report --global --format json --global-cert-enabled
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--format flag cannot be specified when specifying an info flag"* ]]
+}
+
+# --- global scope, cert installed -------------------------------------------
 
 @test "(global-cert:report) --global-cert-enabled is true with a cert" {
   install_fixture_cert
@@ -110,11 +122,77 @@ install_fixture_cert() {
   [ -n "$output" ]
 }
 
-@test "(global-cert:report) full report reflects an installed cert" {
+@test "(global-cert:report) --global full report reflects an installed cert" {
   install_fixture_cert
-  run dokku global-cert:report
+  run dokku global-cert:report --global
   [ "$status" -eq 0 ]
   [[ "$output" == *"Global cert enabled"* ]]
   [[ "$output" == *"true"* ]]
   [[ "$output" == *"global.example.com"* ]]
+}
+
+# --- --format json ----------------------------------------------------------
+
+@test "(global-cert:report) --global --format json emits a json object" {
+  install_fixture_cert
+  run bash -c "dokku global-cert:report --global --format json 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.enabled')" = "true" ]
+  [ "$(echo "$output" | jq -r '.dir')" = "$(global_cert_root)" ]
+  [ "$(echo "$output" | jq -r '.hostnames')" = "global.example.com www.example.com" ]
+  # keys are stripped of the --global-cert- prefix; applied is app-specific
+  [ "$(echo "$output" | jq -r 'has("applied")')" = "false" ]
+}
+
+# --- app scope --------------------------------------------------------------
+
+@test "(global-cert:report) --global-cert-applied is true after applying the global cert" {
+  install_fixture_cert
+  create_app "$APP"
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+
+  run bash -c "dokku global-cert:report '$APP' --global-cert-applied 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "(global-cert:report) --global-cert-applied is false for an app with its own cert" {
+  install_fixture_cert
+  create_app "$APP"
+
+  # give the app its own, independent certificate
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  run bash -c "dokku global-cert:report '$APP' --global-cert-applied 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "(global-cert:report) app report shows the applied status and cert info" {
+  install_fixture_cert
+  create_app "$APP"
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+
+  run dokku global-cert:report "$APP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"${APP} global-cert information"* ]]
+  [[ "$output" == *"Global cert applied"* ]]
+  [[ "$output" == *"true"* ]]
+  [[ "$output" == *"global.example.com"* ]]
+}
+
+@test "(global-cert:report) app-scope --format json includes the applied key" {
+  install_fixture_cert
+  create_app "$APP"
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+
+  run bash -c "dokku global-cert:report '$APP' --format json 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.applied')" = "true" ]
+  [ "$(echo "$output" | jq -r '.enabled')" = "true" ]
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -41,12 +41,14 @@ reset_global_cert() {
   $SUDO rm -f "$(global_cert_crt)" "$(global_cert_key)" "$(global_cert_csr)"
 }
 
-# Value of a single report info flag, with openssl's verify chatter suppressed.
-# `global-cert:report` builds its full flag map up front, so `openssl verify` on
-# a self-signed cert prints "self-signed certificate" warnings to stderr even
-# when an unrelated flag is requested; drop stderr so callers see just the value.
+# Value of a single global-scope report info flag, with openssl's verify chatter
+# suppressed. `global-cert:report` builds its full flag map up front, so `openssl
+# verify` on a self-signed cert prints "self-signed certificate" warnings to
+# stderr even when an unrelated flag is requested; drop stderr so callers see just
+# the value. A bare info flag now reports per-app, so `--global` selects the global
+# certificate scope these helpers assert against.
 global_cert_report_value() {
-  dokku global-cert:report "$1" 2>/dev/null
+  dokku global-cert:report --global "$1" 2>/dev/null
 }
 
 # Report the plugin's view of whether a global cert is installed.


### PR DESCRIPTION
The report now covers individual apps and the global certificate, can be emitted as JSON with `--format json`, and reports whether an app currently serves the global certificate via `--global-cert-applied`, matching the standardized report interface used by the official Dokku plugins.