### PR TITLE
Add release workflows and dependabot, and expand test coverage

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,57 @@
+---
+name: "bump-version"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Bump type"
+        default: "patch"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+env:
+  GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+jobs:
+  bump-version:
+    name: bump-version
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ env.GITHUB_ACCESS_TOKEN }}
+
+      - name: Get Latest Tag
+        id: latest-tag
+        run: |
+          echo GIT_LATEST_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")" >>"$GITHUB_OUTPUT"
+
+      - name: Compute Next Tag
+        id: next-tag
+        uses: docker://ghcr.io/dokku/semver-generator:latest
+        with:
+          bump: ${{ github.event.inputs.bump_type }}
+          input: ${{ steps.latest-tag.outputs.GIT_LATEST_TAG }}
+
+      - name: Bump plugin.toml and Push Release
+        run: |
+          git config --global user.name 'Dokku Bot'
+          git config --global user.email no-reply@dokku.com
+          VERSION="${GIT_NEXT_TAG#v}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" plugin.toml
+          git add plugin.toml
+          git commit -m "Release $VERSION"
+          git tag "$GIT_NEXT_TAG"
+          git push origin "HEAD:$GITHUB_REF_NAME"
+          git push origin "$GIT_NEXT_TAG"
+        env:
+          GIT_NEXT_TAG: ${{ steps.next-tag.outputs.version }}

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -1,0 +1,20 @@
+---
+name: "tagged-release"
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  tagged-release:
+    name: tagged-release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Release
+        uses: softprops/action-gh-release@v3.0.1
+        with:
+          generate_release_notes: true
+          make_latest: "true"

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,8 @@
 
 The bats suite exercises the plugin end-to-end inside a docker-compose stack: a derived dokku image with the plugin source bind-mounted at `/plugin-src`. Tests run inside the dokku container so they call `dokku ...` directly. Apps are created with `apps:create` but never deployed - every assertion is made against the files the plugin manages (`/var/lib/dokku/config/global-cert/server.{crt,key,csr}`) and against `dokku global-cert:report` output. Lifecycle triggers the plugin hooks into - `install`, `uninstall`, `post-create`, and `post-app-clone` - are exercised either through real dokku commands (`apps:create`, `apps:clone`) or by invoking the plugin's own trigger scripts directly (with the dokku plugin environment the CLI would normally export), so no deploy is required.
 
+Most files are black-box tests that drive the CLI. `global_cert_internal.bats` is the one exception: it sources `internal-functions` directly (via the `run_internal_fn` helper) to assert branches that the CLI cannot reach deterministically in a single run - most notably the `certs-set` trigger vs `certs:add` fallback, which is otherwise fixed by the installed dokku version. It overrides `PLUGIN_ENABLED_PATH` with a throwaway sandbox so both branches can be asserted regardless of the dokku version under test.
+
 ## Running the suite locally
 
 From the repo root:
@@ -68,3 +70,7 @@ make clean-native
 | `make clean-native` | No-op - global-cert needs no supporting compose services. The native dokku install itself is left in place. |
 
 `setup-native` honors `DOKKU_TAG` to install a specific Dokku release instead of master.
+
+## Continuous integration
+
+`.github/workflows/ci.yml` runs both the compose and native modes on every push to `master` and every pull request, across a matrix of dokku versions. Two more workflows handle releases: `tagged-release.yaml` publishes a GitHub release when a tag is pushed, and `bump-version.yaml` is a manual dispatch that bumps `plugin.toml` and pushes a new tag (it requires a `GH_ACCESS_TOKEN` repo secret to push). `.github/dependabot.yaml` keeps the GitHub Actions used by these workflows up to date.

--- a/tests/global_cert_apply.bats
+++ b/tests/global_cert_apply.bats
@@ -102,3 +102,42 @@ install_fixture_cert() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"Please specify an app to run the command on"* ]]
 }
+
+@test "(global-cert:apply) installs the exact global certificate" {
+  install_fixture_cert
+  create_app "$APP"
+
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+  # a fingerprint match, not just a report substring, proves the exact cert landed
+  assert_app_serves_global_cert "$APP"
+}
+
+@test "(global-cert:apply) verifies every app name before applying to any" {
+  install_fixture_cert
+  create_app "$APP"
+
+  # give the app its own cert so we can tell whether a failed apply touched it
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  run dokku global-cert:apply "$APP" "does-not-exist-$$"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+
+  # verification runs for the whole list before any apply, so the valid app is
+  # left serving its own cert
+  refute_app_serves_global_cert "$APP"
+}
+
+@test "(global-cert:apply) is idempotent" {
+  install_fixture_cert
+  create_app "$APP"
+
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+  assert_app_serves_global_cert "$APP"
+}

--- a/tests/global_cert_generate.bats
+++ b/tests/global_cert_generate.bats
@@ -45,3 +45,24 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Global SSL endpoint already defined"* ]]
 }
+
+@test "(global-cert:generate) installs the crt and csr 640 and the config dir 750" {
+  run gc_generate
+  [ "$status" -eq 0 ]
+  local cperms sperms dperms
+  cperms="$($SUDO stat -c '%a' "$(global_cert_crt)")"
+  sperms="$($SUDO stat -c '%a' "$(global_cert_csr)")"
+  dperms="$($SUDO stat -c '%a' "$(global_cert_root)")"
+  [ "$cperms" = "640" ]
+  [ "$sperms" = "640" ]
+  [ "$dperms" = "750" ]
+}
+
+@test "(global-cert:generate) produces a cert the report marks enabled and self signed" {
+  run gc_generate
+  [ "$status" -eq 0 ]
+  run global_cert_report_value --global-cert-enabled
+  [ "$output" = "true" ]
+  run global_cert_report_value --global-cert-verified
+  [ "$output" = "self signed" ]
+}

--- a/tests/global_cert_help.bats
+++ b/tests/global_cert_help.bats
@@ -81,3 +81,22 @@ load 'test_helper'
   [[ "$output" == *"usage:"* ]]
   [[ "$output" == *"global-cert:update"* ]]
 }
+
+@test "(global-cert:help remove) prints per-subcommand usage" {
+  run dokku global-cert:help remove
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"usage:"* ]]
+  [[ "$output" == *"global-cert:remove"* ]]
+}
+
+@test "(global-cert:help set) renders the --force flag" {
+  run dokku global-cert:help set
+  [ "$status" -eq 0 ]
+  # the #F annotation renders --force in a flags section
+  [[ "$output" == *"--force"* ]]
+}
+
+@test "(global-cert:help) an unknown subcommand exits non-zero" {
+  run dokku global-cert:help bogus-subcommand
+  [ "$status" -ne 0 ]
+}

--- a/tests/global_cert_internal.bats
+++ b/tests/global_cert_internal.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+# White-box unit tests that source internal-functions directly (via
+# run_internal_fn) to reach branches that are impossible or non-deterministic to
+# assert through the CLI in a single run. The clearest example is the
+# certs-set-trigger vs certs:add fallback: which path runs is fixed by the
+# installed dokku version, so no black-box test can assert both branches at
+# once; overriding PLUGIN_ENABLED_PATH with a controlled sandbox can.
+
+load 'test_helper'
+
+setup() {
+  FIXTURES=()
+}
+
+teardown() {
+  local f
+  for f in "${FIXTURES[@]}"; do
+    [ -n "$f" ] && rm -rf "$f"
+  done
+  return 0
+}
+
+# --- fn-global-cert-certs-set-available -------------------------------------
+
+@test "(fn-global-cert-certs-set-available) returns 0 when an enabled plugin ships an executable certs-set" {
+  local enabled
+  enabled="$(make_certs_set_sandbox with-trigger)"
+  FIXTURES+=("$enabled")
+
+  run run_internal_fn ENABLED_PATH="$enabled" fn-global-cert-certs-set-available
+  [ "$status" -eq 0 ]
+}
+
+@test "(fn-global-cert-certs-set-available) returns 1 when no enabled plugin ships certs-set" {
+  local enabled
+  enabled="$(make_certs_set_sandbox)"
+  FIXTURES+=("$enabled")
+
+  run run_internal_fn ENABLED_PATH="$enabled" fn-global-cert-certs-set-available
+  [ "$status" -eq 1 ]
+}
+
+# --- fn-get-ssl-hostnames ---------------------------------------------------
+
+@test "(fn-get-ssl-hostnames) yields no names for a CN-only cert (extraction is SAN-based)" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  make_self_signed_cert "$dir" "cn-only.example.com"
+
+  # hostnames are derived from the SAN extension; a cert with only a CN and no
+  # SAN yields nothing on OpenSSL 3.x, whose subject prints "CN = ..." so the
+  # legacy "/CN=" pipeline finds no match. The else branch still exits cleanly.
+  run run_internal_fn fn-get-ssl-hostnames "$dir"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "(fn-get-ssl-hostnames) returns the SAN entries sorted and de-duplicated" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  # SANs are intentionally out of order and contain a duplicate to exercise the
+  # sort -u at the end of the function
+  make_self_signed_cert "$dir" "a.example.com" \
+    "DNS:b.example.com,DNS:a.example.com,DNS:b.example.com,DNS:c.example.com"
+
+  run run_internal_fn fn-get-ssl-hostnames "$dir"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "a.example.com" ]
+  [ "${lines[1]}" = "b.example.com" ]
+  [ "${lines[2]}" = "c.example.com" ]
+}
+
+# --- fn-global-cert-fingerprint ---------------------------------------------
+
+@test "(fn-global-cert-fingerprint) prints the sha256 fingerprint of a readable cert" {
+  local dir expected
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  make_self_signed_cert "$dir" "fp.example.com"
+  expected="$(openssl x509 -noout -fingerprint -sha256 -in "${dir}/server.crt")"
+
+  run run_internal_fn fn-global-cert-fingerprint "${dir}/server.crt"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "(fn-global-cert-fingerprint) prints nothing and exits 0 for a missing file" {
+  run run_internal_fn fn-global-cert-fingerprint "/tmp/gc-missing-$$-does-not-exist.crt"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "(fn-global-cert-fingerprint) prints nothing for a non-certificate file" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  printf 'not a certificate\n' >"${dir}/notcert.txt"
+  chmod 644 "${dir}/notcert.txt"
+
+  run run_internal_fn fn-global-cert-fingerprint "${dir}/notcert.txt"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- fn-is-ssl-enabled ------------------------------------------------------
+
+@test "(fn-is-ssl-enabled) returns 1 when only the crt is present" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  make_self_signed_cert "$dir" "partial.example.com"
+  rm -f "${dir}/server.key"
+
+  run run_internal_fn fn-is-ssl-enabled "$dir"
+  [ "$status" -eq 1 ]
+}
+
+@test "(fn-is-ssl-enabled) returns 1 when only the key is present" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  make_self_signed_cert "$dir" "partial.example.com"
+  rm -f "${dir}/server.crt"
+
+  run run_internal_fn fn-is-ssl-enabled "$dir"
+  [ "$status" -eq 1 ]
+}
+
+# --- fn-is-file-import ------------------------------------------------------
+
+@test "(fn-is-file-import) returns 0 when both crt and key files exist" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  make_self_signed_cert "$dir" "fi.example.com"
+
+  run run_internal_fn fn-is-file-import "${dir}/server.crt" "${dir}/server.key"
+  [ "$status" -eq 0 ]
+}
+
+@test "(fn-is-file-import) returns 1 when only the crt path is supplied" {
+  local dir
+  dir="$(gc_fixture_dir)"
+  FIXTURES+=("$dir")
+  make_self_signed_cert "$dir" "fi.example.com"
+
+  run run_internal_fn fn-is-file-import "${dir}/server.crt" ""
+  [ "$status" -eq 1 ]
+}

--- a/tests/global_cert_remove.bats
+++ b/tests/global_cert_remove.bats
@@ -60,3 +60,20 @@ install_fixture_cert() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"A global SSL endpoint is not defined"* ]]
 }
+
+@test "(global-cert:remove) leaves a generated csr in place" {
+  gc_generate
+  $SUDO test -f "$(global_cert_csr)"
+
+  run dokku global-cert:remove
+  [ "$status" -eq 0 ]
+
+  # remove deletes only the crt/key endpoint; the csr from generate remains
+  $SUDO test ! -f "$(global_cert_crt)"
+  $SUDO test ! -f "$(global_cert_key)"
+  $SUDO test -f "$(global_cert_csr)"
+
+  run dokku global-cert:show csr
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BEGIN CERTIFICATE REQUEST"* ]]
+}

--- a/tests/global_cert_report.bats
+++ b/tests/global_cert_report.bats
@@ -5,12 +5,14 @@ load 'test_helper'
 setup() {
   reset_global_cert
   APP="$(new_app_name)"
+  APP2=""
   SRC=""
   OWN=""
 }
 
 teardown() {
   cleanup_app "$APP"
+  [ -n "${APP2:-}" ] && cleanup_app "$APP2"
   reset_global_cert
   [ -n "${SRC:-}" ] && rm -rf "$SRC"
   [ -n "${OWN:-}" ] && rm -rf "$OWN"
@@ -195,4 +197,89 @@ install_fixture_cert() {
   [ "$status" -eq 0 ]
   [ "$(echo "$output" | jq -r '.applied')" = "true" ]
   [ "$(echo "$output" | jq -r '.enabled')" = "true" ]
+}
+
+# --- no-app (per-app) scope -------------------------------------------------
+
+@test "(global-cert:report) with no app argument prints a section per installed app" {
+  install_fixture_cert
+  create_app "$APP"
+  APP2="$(new_app_name)"
+  create_app "$APP2"
+
+  run dokku global-cert:report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"${APP} global-cert information"* ]]
+  [[ "$output" == *"${APP2} global-cert information"* ]]
+}
+
+@test "(global-cert:report) with a bare info flag and no app prints the value per app" {
+  install_fixture_cert
+  create_app "$APP"
+  APP2="$(new_app_name)"
+  create_app "$APP2"
+
+  run bash -c "dokku global-cert:report --global-cert-dir 2>/dev/null"
+  [ "$status" -eq 0 ]
+  # the app-independent dir prints once per app; both of ours are represented
+  local count
+  count="$(printf '%s\n' "$output" | grep -c "^$(global_cert_root)$")"
+  [ "$count" -ge 2 ]
+}
+
+# --- --format json edge cases -----------------------------------------------
+
+@test "(global-cert:report) --global --format json without a cert emits enabled false and empty values" {
+  run bash -c "dokku global-cert:report --global --format json 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.enabled')" = "false" ]
+  [ "$(echo "$output" | jq -r '.hostnames')" = "" ]
+  [ "$(echo "$output" | jq -r '.issuer')" = "" ]
+}
+
+@test "(global-cert:report) --global --format json exposes the full key set with the prefix stripped" {
+  install_fixture_cert
+  run bash -c "dokku global-cert:report --global --format json 2>/dev/null"
+  [ "$status" -eq 0 ]
+  local keys
+  keys="$(echo "$output" | jq -r '. | keys | sort | join(",")')"
+  [ "$keys" = "dir,enabled,expires-at,hostnames,issuer,starts-at,subject,verified" ]
+  # applied is app-specific and must not appear in the global scope
+  [ "$(echo "$output" | jq -r 'has("applied")')" = "false" ]
+}
+
+# --- app scope, error and applied branches ----------------------------------
+
+@test "(global-cert:report) on a nonexistent app fails via verify_app_name" {
+  run dokku global-cert:report "does-not-exist-$$"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "(global-cert:report) --global-cert-applied is false when no global cert is installed" {
+  create_app "$APP"
+  run bash -c "dokku global-cert:report '$APP' --global-cert-applied 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "(global-cert:report) --global-cert-applied is false after the app cert is removed" {
+  install_fixture_cert
+  create_app "$APP"
+  run dokku global-cert:apply "$APP"
+  [ "$status" -eq 0 ]
+
+  dokku certs:remove "$APP"
+
+  run bash -c "dokku global-cert:report '$APP' --global-cert-applied 2>/dev/null"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "(global-cert:report) app scope rejects --format combined with an info flag" {
+  install_fixture_cert
+  create_app "$APP"
+  run dokku global-cert:report "$APP" --format json --global-cert-applied
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--format flag cannot be specified when specifying an info flag"* ]]
 }

--- a/tests/global_cert_set.bats
+++ b/tests/global_cert_set.bats
@@ -6,11 +6,16 @@ setup() {
   reset_global_cert
   SRC="$(gc_fixture_dir)"
   make_self_signed_cert "$SRC" "global.example.com"
+  APP=""
+  OWN=""
 }
 
 teardown() {
+  [ -n "${APP:-}" ] && cleanup_app "$APP"
   reset_global_cert
   rm -rf "$SRC"
+  [ -n "${OWN:-}" ] && rm -rf "$OWN"
+  return 0
 }
 
 # --- file import ------------------------------------------------------------
@@ -124,4 +129,65 @@ teardown() {
   run dokku global-cert:set <"$tarball"
   [ "$status" -ne 0 ]
   [[ "$output" == *"Tar archive contains more than one .key file"* ]]
+}
+
+# --- sync / propagation -----------------------------------------------------
+
+@test "(global-cert:set) logs Applying then Re-applying as the cert is set and renewed" {
+  APP="$(new_app_name)"
+  create_app "$APP"
+
+  run dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Applying global certificate to $APP"* ]]
+
+  # a second, different cert is a renewal: the app currently serves the previous
+  # global cert, so the sync re-applies rather than skips it
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "global2.example.com"
+
+  run dokku global-cert:set "${OWN}/server.crt" "${OWN}/server.key"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Re-applying global certificate to $APP"* ]]
+}
+
+@test "(global-cert:set) -f reapplies to an app that has its own certificate" {
+  APP="$(new_app_name)"
+  create_app "$APP"
+
+  # the app gets its own, independent cert first
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  run dokku global-cert:set -f "${SRC}/server.crt" "${SRC}/server.key"
+  [ "$status" -eq 0 ]
+  assert_app_serves_global_cert "$APP"
+}
+
+@test "(global-cert:set) accepts --force after the file paths" {
+  APP="$(new_app_name)"
+  create_app "$APP"
+
+  OWN="$(gc_fixture_dir)"
+  make_self_signed_cert "$OWN" "own.example.com" "DNS:own.example.com"
+  dokku certs:add "$APP" "${OWN}/server.crt" "${OWN}/server.key"
+
+  run dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key" --force
+  [ "$status" -eq 0 ]
+  assert_app_serves_global_cert "$APP"
+}
+
+@test "(global-cert:set) is idempotent when the same cert is set twice" {
+  APP="$(new_app_name)"
+  create_app "$APP"
+
+  dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+  assert_app_serves_global_cert "$APP"
+
+  run dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+  [ "$status" -eq 0 ]
+  run global_cert_enabled
+  [ "$output" = "true" ]
+  assert_app_serves_global_cert "$APP"
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -161,3 +161,108 @@ fire_trigger() {
   shift
   dokku_plugin_env "${lib_override[@]}" "$(plugin_script "$script")" "$@"
 }
+
+# --- certificate assertions -------------------------------------------------
+# The plugin's notion of "the app serves the global cert" is a sha256
+# fingerprint match between the app's leaf cert and the global one (see
+# fn-global-cert-applied). These helpers assert that directly instead of
+# grepping `dokku certs:report` text, so a byte-level cert swap is caught.
+
+# sha256 fingerprint of an app's imported cert / of the global cert. Empty when
+# the file is missing or unreadable (mirrors fn-global-cert-fingerprint).
+app_cert_fingerprint() { $SUDO openssl x509 -noout -fingerprint -sha256 -in "$(app_tls_crt "$1")" 2>/dev/null; }
+global_cert_fingerprint() { $SUDO openssl x509 -noout -fingerprint -sha256 -in "$(global_cert_crt)" 2>/dev/null; }
+
+# Assert an app currently serves the exact global certificate.
+assert_app_serves_global_cert() {
+  local app="$1" app_fp global_fp
+  app_fp="$(app_cert_fingerprint "$app")"
+  global_fp="$(global_cert_fingerprint)"
+  if [[ -z "$app_fp" ]]; then
+    echo "expected app $app to serve the global cert, but it has no readable cert" >&2
+    return 1
+  fi
+  if [[ "$app_fp" != "$global_fp" ]]; then
+    echo "app $app cert ($app_fp) does not match the global cert ($global_fp)" >&2
+    return 1
+  fi
+}
+
+# Assert an app has a cert whose fingerprint differs from the global one (i.e.
+# its own, independent cert).
+refute_app_serves_global_cert() {
+  local app="$1" app_fp global_fp
+  app_fp="$(app_cert_fingerprint "$app")"
+  global_fp="$(global_cert_fingerprint)"
+  if [[ -z "$app_fp" ]]; then
+    echo "expected app $app to have its own cert, but it has none" >&2
+    return 1
+  fi
+  if [[ "$app_fp" == "$global_fp" ]]; then
+    echo "expected app $app not to serve the global cert, but it does ($app_fp)" >&2
+    return 1
+  fi
+}
+
+# openssl accessors for an app's imported cert, ported from dokku-letsencrypt's
+# cert_subject/cert_issuer/cert_san helpers.
+app_cert_subject() { $SUDO openssl x509 -in "$(app_tls_crt "$1")" -noout -subject 2>/dev/null; }
+app_cert_issuer() { $SUDO openssl x509 -in "$(app_tls_crt "$1")" -noout -issuer 2>/dev/null; }
+app_cert_san() {
+  $SUDO openssl x509 -in "$(app_tls_crt "$1")" -noout -text 2>/dev/null |
+    grep --after-context=1 'Subject Alternative Name' | tail -n 1 | xargs
+}
+
+# Assert the app cert's SAN list contains <needle>.
+assert_app_cert_san_contains() {
+  local app="$1" needle="$2"
+  app_cert_san "$app" | grep -qF "$needle"
+}
+
+# Thin wrappers over the repeated `$SUDO test -f` on an app's TLS cert.
+assert_app_has_cert() { $SUDO test -f "$(app_tls_crt "$1")"; }
+refute_app_has_cert() { $SUDO test ! -f "$(app_tls_crt "$1")"; }
+
+# --- internal-function unit-test plumbing -----------------------------------
+# Source the installed internal-functions and run a single function under the
+# plugin environment, capturing status/output the way bats' `run` expects.
+# Leading `ENABLED_PATH=<dir>` / `LIB_ROOT=<dir>` override PLUGIN_ENABLED_PATH /
+# DOKKU_LIB_ROOT so version-fixed branches (certs-set vs certs:add) and config
+# roots can be driven deterministically. `set +e` is re-enabled after sourcing
+# because internal-functions sets `set -eo pipefail`, which would otherwise
+# abort the shell (and lose $status) on any function that returns non-zero.
+run_internal_fn() {
+  local env_overrides=()
+  while [[ "${1:-}" == ENABLED_PATH=* || "${1:-}" == LIB_ROOT=* ]]; do
+    case "$1" in
+      ENABLED_PATH=*) env_overrides+=(PLUGIN_ENABLED_PATH="${1#ENABLED_PATH=}") ;;
+      LIB_ROOT=*) env_overrides+=(DOKKU_LIB_ROOT="${1#LIB_ROOT=}") ;;
+    esac
+    shift
+  done
+  # the $1/$@ inside the single-quoted script are expanded by the inner bash -c,
+  # not the current shell, which is exactly what we want here
+  # shellcheck disable=SC2016
+  dokku_plugin_env "${env_overrides[@]}" bash -c '
+    source "$1"
+    set +e
+    shift
+    "$@"
+  ' _ "$(plugin_script internal-functions)" "$@"
+}
+
+# Create a throwaway enabled-plugins tree and echo its path. With any argument,
+# it ships an executable `somepkg/certs-set` so fn-global-cert-certs-set-available
+# detects the trigger; without one, the tree is empty (the certs:add fallback).
+# The returned path is world-traversable; callers should `rm -rf` it in teardown.
+make_certs_set_sandbox() {
+  local with_trigger="${1:-}" root
+  root="$(mktemp -d /tmp/gc-enabled.XXXXXX)"
+  chmod 755 "$root"
+  if [[ -n "$with_trigger" ]]; then
+    mkdir -p "$root/somepkg"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$root/somepkg/certs-set"
+    chmod +x "$root/somepkg/certs-set"
+  fi
+  echo "$root"
+}


### PR DESCRIPTION
The bats suite and CI workflow already mirror dokku-letsencrypt, so this fills the remaining gaps against that reference and broadens coverage. It adds a tagged-release workflow that publishes a GitHub release on tag push, a manual bump-version workflow that updates `plugin.toml` and pushes the new tag, and a dependabot config for the GitHub Actions used across the workflows.

It also adds a white-box unit file that sources `internal-functions` directly to assert branches the CLI cannot reach deterministically, most notably the `certs-set` trigger versus the `certs:add` fallback, along with fingerprint-based certificate assertions and further cases across the report, apply, set, generate, remove, and help subcommands. The full suite passes in compose mode on dokku 0.38.3 and 0.38.22.

The bump-version workflow needs a `GH_ACCESS_TOKEN` repository secret configured before its first dispatch.
