### PR TITLE
fix: parse cert CN and subject on OpenSSL 3.x

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -19,7 +19,7 @@ fn-get-ssl-hostnames() {
   declare SSL_PATH="$1"
   local SSL_HOSTNAME SSL_HOSTNAMES SSL_HOSTNAME_ALT
 
-  SSL_HOSTNAME=$(openssl x509 -in "$SSL_PATH/server.crt" -noout -subject | tr '/' '\n' | grep CN= | cut -c4-)
+  SSL_HOSTNAME=$(openssl x509 -in "$SSL_PATH/server.crt" -noout -subject -nameopt RFC2253 | sed -n 's/.*CN=\([^,]*\).*/\1/p')
   SSL_HOSTNAME_ALT=$(openssl x509 -in "$SSL_PATH/server.crt" -noout -text | grep --after-context=1 '509v3 Subject Alternative Name:' | tail -n 1 | sed -e "s/[[:space:]]*DNS://g"  | tr ',' '\n' || true)
   if [[ -n "$SSL_HOSTNAME_ALT" ]]; then
     SSL_HOSTNAMES="${SSL_HOSTNAME}\n${SSL_HOSTNAME_ALT}"
@@ -248,7 +248,7 @@ fn-ssl-starts-at() {
 
 fn-ssl-subject() {
   if fn-is-ssl-enabled "$PLUGIN_CONFIG_ROOT"; then
-    openssl x509 -in "$PLUGIN_CONFIG_ROOT/server.crt" -noout -subject | sed -e "s:subject= ::g"| sed -e "s:^/::g" | sed -e "s:/:; :g"
+    openssl x509 -in "$PLUGIN_CONFIG_ROOT/server.crt" -noout -subject -nameopt compat | sed -e 's:^subject= *::' -e 's:^/::' -e 's:/:; :g'
   fi
 }
 

--- a/tests/global_cert_internal.bats
+++ b/tests/global_cert_internal.bats
@@ -43,18 +43,18 @@ teardown() {
 
 # --- fn-get-ssl-hostnames ---------------------------------------------------
 
-@test "(fn-get-ssl-hostnames) yields no names for a CN-only cert (extraction is SAN-based)" {
+@test "(fn-get-ssl-hostnames) returns the CN for a CN-only cert" {
   local dir
   dir="$(gc_fixture_dir)"
   FIXTURES+=("$dir")
   make_self_signed_cert "$dir" "cn-only.example.com"
 
-  # hostnames are derived from the SAN extension; a cert with only a CN and no
-  # SAN yields nothing on OpenSSL 3.x, whose subject prints "CN = ..." so the
-  # legacy "/CN=" pipeline finds no match. The else branch still exits cleanly.
+  # a cert with only a CN and no SAN reports its CN. The subject is normalized
+  # with -nameopt RFC2253 so the CN is extracted regardless of the OpenSSL
+  # version's subject formatting (legacy "/CN=" vs OpenSSL 3.x "CN = ").
   run run_internal_fn fn-get-ssl-hostnames "$dir"
   [ "$status" -eq 0 ]
-  [ -z "$output" ]
+  [ "$output" = "cn-only.example.com" ]
 }
 
 @test "(fn-get-ssl-hostnames) returns the SAN entries sorted and de-duplicated" {

--- a/tests/global_cert_report.bats
+++ b/tests/global_cert_report.bats
@@ -93,11 +93,26 @@ install_fixture_cert() {
   [ "$output" = "global.example.com www.example.com" ]
 }
 
+@test "(global-cert:report) --global-cert-hostnames reports the CN for a CN-only cert" {
+  # a cert with only a CN and no SAN still reports its CN; the subject is
+  # normalized so the CN is extracted regardless of the OpenSSL version.
+  SRC="$(gc_fixture_dir)"
+  make_self_signed_cert "$SRC" "cn-only.example.com"
+  dokku global-cert:set "${SRC}/server.crt" "${SRC}/server.key"
+
+  run global_cert_report_value --global-cert-hostnames
+  [ "$status" -eq 0 ]
+  [ "$output" = "cn-only.example.com" ]
+}
+
 @test "(global-cert:report) --global-cert-subject reflects the cert subject" {
   install_fixture_cert
   run global_cert_report_value --global-cert-subject
   [ "$status" -eq 0 ]
-  [[ "$output" == *"global.example.com"* ]]
+  # the subject is normalized (-nameopt compat): the "subject=" prefix is
+  # stripped and RDNs are "; "-joined. The fixture's subject is only a CN, so it
+  # reports exactly "CN=...".
+  [ "$output" = "CN=global.example.com" ]
 }
 
 @test "(global-cert:report) --global-cert-issuer reflects the cert issuer" {


### PR DESCRIPTION
`fn-get-ssl-hostnames` and `fn-ssl-subject` parsed `openssl x509 -subject` output using pre-3.x formatting assumptions, so on OpenSSL 3.x a certificate whose subject carries only a Common Name reported no hostnames and the subject rendered with a stray `subject=` prefix. Normalizing the subject with `-nameopt` makes the extraction independent of the OpenSSL version.

The same bug exists in dokku core and is reported upstream at dokku/dokku#8832.

Fixes #20